### PR TITLE
Pin dependencies for reproducible installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Note: the results do not account for fees during trades. This can have a signifi
 pip3 install -r requirements.txt
 ```
 
+The dependencies in `requirements.txt` are pinned to specific versions for
+consistent results. When new releases appear, update the version numbers in this
+file and rerun the installation command.
+
 ### Usage
 Start detection by running:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ccxt
-networkx[default]
+ccxt==4.2.5
+networkx[default]==3.2.1
 
-OctoBot-Commons>=1.9, <1.10
+OctoBot-Commons==1.9.0


### PR DESCRIPTION
## Summary
- pin exact versions in `requirements.txt`
- mention pinned dependencies in README and how to update them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'octobot_commons')*

------
https://chatgpt.com/codex/tasks/task_e_68450f7609cc832288983f6e65f65ea9