### PR TITLE
Add multi-exchange scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ New 2.33873% binanceus opportunity:
 ```
 
 ### Configuration
-To change the exchange edit `main.py` `exchange_name` value to the desired exchange. It should match the exchange [ccxt id value](https://github.com/ccxt/ccxt?tab=readme-ov-file#certified-cryptocurrency-exchanges)
+To change the exchanges edit `main.py` `exchange_names` list to the desired exchanges. Each value should match the exchange [ccxt id value](https://github.com/ccxt/ccxt?tab=readme-ov-file#certified-cryptocurrency-exchanges)
 
 You can also provide a list of symbol to ignore when calling `run_detection` using `ignored_symbols` and a list of symbol to whitelist using `whitelisted_symbols`.
 

--- a/main.py
+++ b/main.py
@@ -17,9 +17,13 @@ if __name__ == "__main__":
 
     # start arbitrage detection
     print("Scanning...")
-    exchange_name = "binanceus"  # allow pickable exchange_id from https://github.com/ccxt/ccxt/wiki/manual#exchanges
+    exchange_names = [
+        "binanceus"
+    ]  # allow pickable exchange_id from https://github.com/ccxt/ccxt/wiki/manual#exchanges
 
-    best_opportunities, best_profit = asyncio.run(detector.run_detection(exchange_name))
+    best_opportunities, best_profit = asyncio.run(
+        detector.run_detection_multiple_exchanges(exchange_names)
+    )
 
 
     def opportunity_symbol(opportunity):
@@ -34,7 +38,8 @@ if __name__ == "__main__":
         # Display arbitrage detection result
         print("-------------------------------------------")
         total_profit_percentage = round((best_profit - 1) * 100, 5)
-        print(f"New {total_profit_percentage}% {exchange_name} opportunity:")
+        exchange_list = ", ".join(exchange_names)
+        print(f"New {total_profit_percentage}% {exchange_list} opportunity:")
         for i, opportunity in enumerate(best_opportunities):
             # Get the base and quote currencies
             base_currency = opportunity.symbol.base


### PR DESCRIPTION
## Summary
- support multiple exchanges via `run_detection_multiple_exchanges`
- call the new API from `main.py`
- document the new `exchange_names` configuration
- test multi-exchange detection with monkeypatching

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'octobot_commons')*

------
https://chatgpt.com/codex/tasks/task_e_68450d8c7108832294622dc22cadf05c