### PR TITLE
Optimize get_last_prices symbol parsing

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,6 +1,11 @@
 import pytest
 import octobot_commons.symbols as symbols
-from triangular_arbitrage.detector import ShortTicker, get_best_triangular_opportunity, get_best_opportunity
+from triangular_arbitrage.detector import (
+    ShortTicker,
+    get_best_triangular_opportunity,
+    get_best_opportunity,
+    get_last_prices,
+)
 
 
 @pytest.fixture
@@ -96,3 +101,16 @@ def test_get_best_opportunity_returns_correct_cycle_with_multiple_tickers():
     assert len(best_opportunity) >= 3  # Handling cycles with more than 3 tickers
     assert round(best_profit, 3) == 5.775
     assert all(isinstance(ticker, ShortTicker) for ticker in best_opportunity)
+
+
+def test_get_last_prices_returns_same_data():
+    tickers = {
+        'BTC/USDT': {'close': 30000, 'timestamp': 0},
+        'ETH/USDT': {'close': 2000, 'timestamp': 0},
+    }
+    result = get_last_prices(0, tickers, [])
+    expected = [
+        ShortTicker(symbol=symbols.Symbol('BTC/USDT'), last_price=30000),
+        ShortTicker(symbol=symbols.Symbol('ETH/USDT'), last_price=2000),
+    ]
+    assert result == expected

--- a/triangular_arbitrage/detector.py
+++ b/triangular_arbitrage/detector.py
@@ -34,15 +34,28 @@ def is_delisted_symbols(exchange_time, ticker,
 
 
 def get_last_prices(exchange_time, tickers, ignored_symbols, whitelisted_symbols=None):
-    return [
-        ShortTicker(symbol=get_symbol_from_key(key),
-                    last_price=tickers[key]['close'])
-        for key, _ in tickers.items()
-        if tickers[key]['close'] is not None
-           and not is_delisted_symbols(exchange_time, tickers[key])
-           and str(get_symbol_from_key(key)) not in ignored_symbols
-           and (whitelisted_symbols is None or str(get_symbol_from_key(key)) in whitelisted_symbols)
-    ]
+    last_prices = []
+    for key, ticker in tickers.items():
+        symbol = get_symbol_from_key(key)
+        if symbol is None:
+            continue
+
+        if ticker['close'] is None:
+            continue
+
+        if is_delisted_symbols(exchange_time, ticker):
+            continue
+
+        symbol_str = str(symbol)
+        if symbol_str in ignored_symbols:
+            continue
+
+        if whitelisted_symbols is not None and symbol_str not in whitelisted_symbols:
+            continue
+
+        last_prices.append(ShortTicker(symbol=symbol, last_price=ticker['close']))
+
+    return last_prices
 
 
 def get_best_triangular_opportunity(tickers: List[ShortTicker]) -> Tuple[List[ShortTicker], float]:


### PR DESCRIPTION
## Summary
- optimize symbol parsing in `get_last_prices` so each key is parsed only once
- expand detector tests for new get_last_prices behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'octobot_commons')*

------
https://chatgpt.com/codex/tasks/task_e_68450b7f488883228bc3d4f68baa8d99