### PR TITLE
Update README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ New 2.33873% binanceus opportunity:
 ### Configuration
 To change the exchange edit `main.py` `exchange_name` value to the desired exchange. It should match the exchange [ccxt id value](https://github.com/ccxt/ccxt?tab=readme-ov-file#certified-cryptocurrency-exchanges)
 
-You can also provide a list of symbol to ignore when calling `run_detection` using `ignored_symbols` and a list of symbol to whitelist using `whitelisted_symbols`.
+You can also provide a list of symbols to ignore when calling `run_detection` using `ignored_symbols` and a list of symbols to whitelist using `whitelisted_symbols`.
 
 ## Help
 


### PR DESCRIPTION
## Summary
- fix grammar for README configuration note

## Testing
- `markdownlint -V` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68450b7de06c8322af527d5066928690